### PR TITLE
Fixed spelling mistage and prevented multiple saving of event history

### DIFF
--- a/src/command_embeds.py
+++ b/src/command_embeds.py
@@ -85,12 +85,15 @@ def save_event() -> discord.Embed:
         embed.add_field(name="Fehler", value="Wärend einem Laufendem Event kann nicht gespeichert werden!")
         return embed
 
-    store_event_results([1, 75, 271])
+    success_status = store_event_results([1, 75, 271])
 
     embed = discord.Embed(title="Eventübersicht", colour=discord.Colour(0xbf6b0a))
     embed.set_author(name="Event Bot", icon_url="https://cdn.discordapp.com/embed/avatars/0.png")
     embed.set_footer(text="Calculation finished...", icon_url="https://cdn.discordapp.com/embed/avatars/0.png")
-    embed.add_field(name="Done", value="Die Ergebnisse des letzten Events wurden gespeichert")
+    if success_status:
+        embed.add_field(name="Done", value="Die Ergebnisse des letzten Events wurden gespeichert")
+    else:
+        embed.add_field(name="Error", value="Die Ergebnisse wurden nicht gespeichet! (Wahrscheinlich weil schon gespeichert wurde.)")
     return embed
 
 

--- a/src/util/calculations.py
+++ b/src/util/calculations.py
@@ -306,7 +306,7 @@ deep_town_items_prices = {
     "Grape": 1500,
     "Liana": 1700,
     "Steel Plate": 1800,
-    "Ciruits": 2070,
+    "Circuits": 2070,
     "Zip Drive": 2200,
     "Gunpowder": 2500,
     "Titanium Bar": 3000,

--- a/src/util/storage_api.py
+++ b/src/util/storage_api.py
@@ -73,10 +73,11 @@ def store_event_results(guild_ids: list) -> bool:
             "donations": get_total_donations(guild_id),
             "active": get_active_players(guild_id)
         }
-        event_data[guild_id] = guild_data
+        event_data[f"{guild_id}"] = guild_data
 
     # Prevent duplicates
-    if event_data == __read_last_line('util/data/event_history.txt'):
+    last_stored_event = __read_last_line('util/data/event_history.txt')
+    if last_stored_event == event_data:
         return False
 
     __append_dict_to_file('util/data/event_history.txt', event_data)


### PR DESCRIPTION
Fixed spelling mistake
Prevented duplicates in event history
Added error message if event could not be saved to event history